### PR TITLE
Adding reservoir time remaining estimate

### DIFF
--- a/lib/minimed_rf/messages/pump_status.rb
+++ b/lib/minimed_rf/messages/pump_status.rb
@@ -16,8 +16,8 @@ module MinimedRF
         #field_x3: [94,1],
         insulin_remaining: [101,11],
         batt: [116,4],
-        #field_x6: [126,2],
-        #field_x7: [136,6],
+        reservoir_days_remaining: [120, 8],  # "Days" + 1
+        reservoir_minutes_remaining: [128, 16],  # "Minutes" only correlate with pump display during final 24 hours
         sensor_age: [144,8],
         sensor_remaining: [152,8],
         next_cal_hour: [160,8],  # ff at sensor end, 00 at sensor off


### PR DESCRIPTION
This is obviously hard to predict, and it's not that useful. When `reservoir_days_remaining > 1`, the `reservoir_minutes_remaining` is noise, and isn't correlated with the day boundary like you'd expect. Once `reservoir_days_remaining == 1`, the `reservoir_minutes_remaining` correlates with the "Time left: HH:MM" display on the pump status screen.

When the status screen says "Time left: --:--", all three bytes are 0.

Here's my readings as the time left approaches 0. Note that there's a gap of a few hours 
```
01053a, 010534, 010514, 01050e, 010509, 010504, 0104ff, 0104fa, 0104f5, 0104f0, 0104eb, 0104e6, 0104e1, 0104dc, 0104cd, 0104c8, ..., 010055, 010050, 000000
```