### PR TITLE
Added support for the RFSPY_RTSCTS flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ ruby -I lib bin/mmdecode ab29595959655743a5d31c7254ec4b54e55a54b555d0dd0e5555716
 a2 597055 PumpStatus: #101 2014-08-11 18:14:00 -0500 - Glucose=154 PreviousGlucose=156 ActiveInsulin=1.975
 ```
 
+# Flow control
+
+If you're using a device that doesn't have flow control (like the ERF stick), set the appropriate environment variable before use:
+
+```
+export RFSPY_RTSCTS=0
+ruby -I lib bin/mmtune /dev/ttyMFD1 123123
+```
+
 ## Thanks
 
 Thanks to @bewest and @loudnate and others who have provided many insights into the Minimed protocols. Much of the pump-specific knowledge has been figured out by @bewest in his [decoding-carelink](https://github.com/bewest/decoding-carelink) repository.

--- a/lib/minimed_rf/rfspy.rb
+++ b/lib/minimed_rf/rfspy.rb
@@ -29,10 +29,18 @@ module MinimedRF
     def initialize(path)
       @ser = SerialPort.new path
       @ser.baud = 19200
-      @ser.flow_control = SerialPort::HARD
+      @ser.flow_control = rts_cts_flag
       # Non-blocking read
       @ser.read_timeout = -1
       @buf = ""
+    end
+
+    def rts_cts_flag
+      if !ENV.has_key?('RFSPY_RTSCTS') || ENV['RFSPY_RTSCTS'].to_i == 1
+        SerialPort::HARD
+      else
+        SerialPort::NONE
+      end
     end
 
     def update_register(reg, value)


### PR DESCRIPTION
This helps us work with ERF sticks.

If RFSPY_RTSCTS is 1, or not set at all RTS/CTS is enabled. If any other value
it's set to None.

- Added note to README file